### PR TITLE
Decouple information messages from buttons

### DIFF
--- a/resources/scripts/App.vue
+++ b/resources/scripts/App.vue
@@ -23,6 +23,7 @@
             @notifyMemberStatus="toggleMemberHere"
             @switchDriver="switchDriver"
             @updateMemberName="updateMemberName"
+            tooltip="Double-click to set as driver"
             class="grid"
         />
     </form>

--- a/resources/scripts/App.vue
+++ b/resources/scripts/App.vue
@@ -113,7 +113,7 @@ async function onEnd() {
             onBreakTick,
             onEnd
         );
-        information.value = "Break time. Grab a tea! 🍵";
+        information.value = "🍵 Break time. Grab a tea!";
 
         await showWindow();
     } else {
@@ -141,7 +141,6 @@ async function startSession() {
     if (state.timer?.isRunning) return false;
 
     startButtonText.value = "Hide window";
-    information.value = "Session running 🚀. Double click any team member to switch or restart.";
 
     state.timer = startTimer(state.iterationLengthInSeconds, onTick, onEnd);
 

--- a/resources/scripts/App.vue
+++ b/resources/scripts/App.vue
@@ -1,4 +1,5 @@
 <template>
+    <Alert v-if="information" :message="information" @alertClosed="information = ''" />
     <div class="cycle-settings">
         <Timer
             :value="formattedTimeRemaining"
@@ -32,6 +33,7 @@ import { PropType, reactive, ref } from "vue";
 import Timer from "./components/Timer.vue";
 import TeamMember from "./components/TeamMember.vue";
 import BreaksToggle from "./components/BreaksToggle.vue";
+import Alert from "./components/Alert.vue";
 
 import { updateTray, saveTeam, showWindow, hideWindow } from "./neutralino-api";
 import {
@@ -54,6 +56,7 @@ const takeBreaks = ref(true);
 const startButtonText = ref("Start");
 const isPaused = ref(false);
 const team = reactive(props.team);
+const information = ref("");
 
 const state: {
     timer: ReturnType<typeof startTimer> | null;
@@ -110,7 +113,7 @@ async function onEnd() {
             onBreakTick,
             onEnd
         );
-        startButtonText.value = "Take a break!";
+        information.value = "Break time. Grab a tea! 🍵";
 
         await showWindow();
     } else {
@@ -137,8 +140,8 @@ async function startSession() {
 
     if (state.timer?.isRunning) return false;
 
-    startButtonText.value =
-        "Session running 🚀. Double click any team member to switch/restart.";
+    startButtonText.value = "Hide window";
+    information.value = "Session running 🚀. Double click any team member to switch or restart.";
 
     state.timer = startTimer(state.iterationLengthInSeconds, onTick, onEnd);
 

--- a/resources/scripts/components/Alert.vue
+++ b/resources/scripts/components/Alert.vue
@@ -1,0 +1,58 @@
+<template>
+    <div class="alert">
+        <p>{{ message }}</p>
+        <button aria-label="Close" @click="close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+</template>
+
+<script setup lang="ts">
+defineProps({
+    message: {
+        type: String,
+        required: true
+    },
+});
+
+const emit = defineEmits(["alertClosed"]);
+
+function close() {
+    emit("alertClosed");
+}
+</script>
+
+<style scoped>
+.alert {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 20px;
+    margin: 10px;
+    background-color: var(--secondary);
+    opacity: 0.8;
+    border-radius: 3px;
+}
+
+p,
+button {
+    width: auto;
+    margin: 0;
+    color: var(--primary-inverse);
+}
+
+button {
+    background-color: transparent;
+    border: none;
+    padding: 10px 0 10px 10px;
+    font-weight: 600;
+}
+
+button:hover {
+    color: var(--primary);
+}
+</style>

--- a/resources/scripts/components/TeamMember.vue
+++ b/resources/scripts/components/TeamMember.vue
@@ -2,6 +2,7 @@
     <div class="team-member" :class="{ current: isActive }">
         <input type="checkbox" v-model="isHere" role="switch" @click="ensureMinimumMembers" @change="toggleMemberHere">
         <input type="text" :value="name" placeholder="Name" @dblclick="switchDriver" @input="updateMemberName" />
+        <p v-if="tooltip" class="tooltip">{{ tooltip }}</p>
     </div>
 </template>
 
@@ -24,6 +25,9 @@ const props = defineProps({
     onlyOneActiveMember: {
         type: Boolean,
         required: false,
+    },
+    tooltip: {
+        type: String,
     },
 });
 
@@ -68,6 +72,7 @@ function updateMemberName(event: Event) {
     grid-template-columns: 1fr minmax(auto, 95%);
     align-items: center;
     margin-bottom: var(--spacing);
+    position: relative;
 }
 
 .current input[type="text"] {
@@ -79,5 +84,38 @@ function updateMemberName(event: Event) {
     100% {
         filter: hue-rotate(360deg);
     }
+}
+
+.tooltip {
+    position: absolute;
+    top: 50%;
+    right: 15px;
+    margin: 0;
+    padding: 10px;
+    font-size: 0.6em;
+    white-space: nowrap;
+    pointer-events: none;
+    color: var(--color);
+    transform: translateY(-50%);
+    background-color: var(--primary);
+    color: var(--primary-inverse);
+    border-radius: 5px;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.team-member:hover .tooltip {
+    opacity: 0.9;
+}
+
+.tooltip:before {
+    content: "";
+    position: absolute;
+    top: 7px;
+    left: -20px;
+    height: 0;
+    width: 0;
+    border: 10px solid transparent;
+    border-right-color: var(--primary);
 }
 </style>


### PR DESCRIPTION
Fix #36.

- Show alert about break instead of putting information in CTA
- Use tooltip to hint about driver change via double-clicking team member