### PR TITLE
Fix auto-display of minimized window in Windows

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["Vue.volar"]
+    "recommendations": ["Vue.volar", "esbenp.prettier-vscode"]
 }

--- a/neutralino.config.json
+++ b/neutralino.config.json
@@ -60,7 +60,7 @@
         "binaryName": "mobtimer",
         "resourcesPath": "/dist/",
         "extensionsPath": "/extensions/",
-        "binaryVersion": "5.1.0",
+        "binaryVersion": "5.4.0",
         "frontendLibrary": {
             "patchFile": "/resources/index.html",
             "devUrl": "http://localhost:3000",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.7.1",
             "license": "ISC",
             "dependencies": {
-                "@neutralinojs/lib": "^5.1.0",
+                "@neutralinojs/lib": "^5.4.0",
                 "nanoid": "^5.0.8",
                 "vue": "^3.5.13"
             },
@@ -676,9 +676,10 @@
             }
         },
         "node_modules/@neutralinojs/lib": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@neutralinojs/lib/-/lib-5.1.0.tgz",
-            "integrity": "sha512-CcPPP+TdY1Uaprert/bpc6voZS2b5Q8E10mMi5ave1ege+n9ARs5h1GOQQ8liZqMHbJeYu4dcBnIYsHQZQ351g=="
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@neutralinojs/lib/-/lib-5.4.0.tgz",
+            "integrity": "sha512-pWjR8/OQWF3++hHZ3ecCw8v6tXHCLLDoVxm6FyEqdZlF9FdTKpdDyyTj2YjLshsh6zczZblhie/qcdxS7bPRhQ==",
+            "license": "MIT"
         },
         "node_modules/@neutralinojs/neu": {
             "version": "11.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "homepage": "https://github.com/jouni-kantola/mobtimer#readme",
     "dependencies": {
-        "@neutralinojs/lib": "^5.1.0",
+        "@neutralinojs/lib": "^5.4.0",
         "nanoid": "^5.0.8",
         "vue": "^3.5.13"
     },

--- a/resources/scripts/neutralino-api.ts
+++ b/resources/scripts/neutralino-api.ts
@@ -60,7 +60,11 @@ export async function saveIntervalLength(seconds: number) {
 }
 
 export async function showWindow() {
-    await neuWindow.show();
+    if (await neuWindow.isMinimized()) {
+        await neuWindow.unminimize();
+    } else {
+        await neuWindow.show();
+    }
 }
 
 export async function hideWindow() {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,41 @@
+import type { Plugin, ResolvedConfig } from "vite";
+
 import { defineConfig } from "vite";
+import fs from "node:fs/promises";
+import path from "node:path";
+
 import vue from "@vitejs/plugin-vue";
+
+const neutralino = (): Plugin => {
+    let config: ResolvedConfig;
+
+    return {
+        name: "neutralino",
+        configResolved(resolvedConfig) {
+            config = resolvedConfig;
+        },
+        async transformIndexHtml(html) {
+            if (config.mode === "development") {
+                const authInfoFile = await fs.readFile(
+                    path.join(".tmp", "auth_info.json"),
+                    {
+                        encoding: "utf-8",
+                    }
+                );
+
+                const authInfo = JSON.parse(authInfoFile);
+                const port = authInfo.nlPort;
+
+                return html.replace(
+                    /<script src="__neutralino_globals\.js"><\/script>/,
+                    `<script src="http://localhost:${port}/__neutralino_globals.js"></script>`
+                );
+            }
+
+            return html;
+        },
+    };
+};
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,5 +47,5 @@ export default defineConfig({
     server: {
         port: 3000,
     },
-    plugins: [vue()],
+    plugins: [vue(), neutralino()],
 });


### PR DESCRIPTION
Update Neutralino.js to v5.4.0 to enable the API `unminimize()` that fixes #66.

When updating to v5.4.0 dev mode does not start because of some issue with handling `__neutralino_globals.js`. This is now done by a custom Vite plugin.